### PR TITLE
build: use variable for specifying logback version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ project.ext {
 	haleVersion = '5.1.0'
 	cliVersion = '5.1.0-SNAPSHOT'
 	groovyVersion = '2.5.19'
+	logbackVersion = '1.4.11'
 }
 
 dependencies {
@@ -66,8 +67,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	// Logging
-	testRuntimeOnly 'ch.qos.logback:logback-core:1.4.11'
-	testRuntimeOnly 'ch.qos.logback:logback-classic:1.4.11'
+	testRuntimeOnly "ch.qos.logback:logback-core:$logbackVersion"
+	testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 }
 
 configurations.all {


### PR DESCRIPTION
Instead of specifying the version for the two logback dependencies separately, use a variable to specify the version to be used.

This should prevent the problem of renovate upgrading the two dependencies in separate PRs.

SVC-1398