### PR TITLE
build: prevent minor version upgrade of groovy-all dependency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:recommended"
+    ],
+    "packageRules": [
+          {
+            "matchPackageNames": ["org.codehaus.groovy:groovy-all"],
+            "allowedVersions": "<2.6.0"
+          }
     ]
 }


### PR DESCRIPTION
Limit renovate to upgrading the groovy-all dependency to 2.5.x which is used by hale»studio.

SVC-1398