### PR TITLE
build: prevent major version upgrade of eclipse-temurin base image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,10 @@
           {
             "matchPackageNames": ["org.codehaus.groovy:groovy-all"],
             "allowedVersions": "<2.6.0"
+          },
+          {
+            "matchPackageNames": ["eclipse-temurin"],
+            "allowedVersions": "<18.0.0"
           }
     ]
 }


### PR DESCRIPTION
Limit renovate to upgrading the the eclipse-temurin base image to Java 17 which is used by hale»studio.

SVC-1398