### PR TITLE
ci: add required check for default branch

### DIFF
--- a/.wetf-repo.yml
+++ b/.wetf-repo.yml
@@ -1,0 +1,9 @@
+---
+# Repository configuration for wetransform managed repositories
+
+# Reference presets that should apply to this repository
+presets: []
+
+# List of custom required checks
+required_checks:
+  - check


### PR DESCRIPTION
Adds the check `check` to the required checks in the managed repository rules.